### PR TITLE
update jstp-java version

### DIFF
--- a/MetaCom/app/build.gradle
+++ b/MetaCom/app/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     })
     implementation 'com.android.support:appcompat-v7:25.3.1'
 
-    implementation 'com.metarhia.jstp:jstp:0.8.5'
+    implementation 'com.metarhia.jstp:jstp:0.8.6'
     compileOnly group: 'com.metarhia.jstp', name: 'jstp-compiler', version: '0.2.6'
     annotationProcessor group: 'com.metarhia.jstp', name: 'jstp-compiler', version: '0.2.6'
 


### PR DESCRIPTION
This version is compatible with the new jstp@1.0.0 and thus
will fix communication between android client and server which
has been updated to the jstp@1.0.0
(see issue https://github.com/metarhia/server/issues/46).